### PR TITLE
Update README.md (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Open source Computer Aided Dispatch System for GTA V Roleplay Communities.
 * Operating System: Linux
 * Webserver: Apache or Nginx
 * PHP: >= 5.5.0 (Recommended), 5.3.7 (Minimum)
-* Database: MySQL 5.5 or MariaDB 10.0 (Recommended)
+* Database: MySQL 5.6.5+ or MariaDB 10.0 (Recommended)
 
 Note: This could probably run on Apache/PHP/MySQL under Windows but was developed primarily in a Linux environments.
 
 # Support
-Join the our Discord and someone will be able to help.
+Join the our [Discord](https://discord.gg/ufBBmaN "openCAD Discord") and someone will be able to help.


### PR DESCRIPTION
Updated required database version from 5.5 to 5.6.5 as a minimum due to a certain MySQL restriction being lifted that is being utilized.

This is the error you get if you have below 5.6.5 and run the initialization SQL script:
ERROR 1293 (HY000) at line 204: Incorrect table definition; there can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause

MySQL Documentation on the update to 5.6.5:
Changes in MySQL 5.6.5 (2012-04-10, Milestone 8)

Previously, at most one TIMESTAMP column per table could be automatically initialized or updated to the current date and time. This restriction has been lifted. Any TIMESTAMP column definition can have any combination of DEFAULT CURRENT_TIMESTAMP and ON UPDATE CURRENT_TIMESTAMP clauses. In addition, these clauses now can be used with DATETIME column definitions. For more information, see Automatic Initialization and Updating for TIMESTAMP and DATETIME.
Source: https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-5.html

Also added link for the Discord.